### PR TITLE
Fix Makefile redirect command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ generate:
 	uv run -- python -m euromillions generate
 
 generate-with-redirect:
-	-uv run -- python -m euromillions generate >out.txt 2>&1 || true≤
+	-uv run -- python -m euromillions generate >out.txt 2>&1 || true
 stats:
 	uv run -- python -m euromillions stats
 


### PR DESCRIPTION
## Summary
- remove stray character at the end of the generate-with-redirect rule

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878e2273fb88332a18c9321411d6aa7