### PR TITLE
Fix bug in genome ticket generation

### DIFF
--- a/src/euromillions/genetics/genome.py
+++ b/src/euromillions/genetics/genome.py
@@ -41,5 +41,10 @@ def evaluate_chromosome(chromosome: Chromosome) -> float:
     if not selected_variants:
         return 0.0
 
-    tickets = generate_tickets_from_variants(draws_df, selected_variants, max_tickets=7)
+    tickets = generate_tickets_from_variants(
+        chromosome,
+        selected_variants,
+        draws_df,
+        max_tickets=7,
+    )
     return evaluate_ticket_set(tickets, draws_df, prizes_df)


### PR DESCRIPTION
## Summary
- fix argument order when generating tickets in `evaluate_chromosome`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ran a sample script importing the package (fails due to missing data but module import works)

------
https://chatgpt.com/codex/tasks/task_e_6878e117d30c833291d6e7c65acdc0eb