### PR TITLE
Add new probabilistic ticket strategies

### DIFF
--- a/src/euromillions/generators/strategies/age_weighted.py
+++ b/src/euromillions/generators/strategies/age_weighted.py
@@ -1,0 +1,51 @@
+import random
+import pandas as pd
+
+
+def age_weighted_generator_factory(exponent: float = 1.0):
+    """Generate tickets giving more weight to numbers not drawn recently."""
+
+    def generator(draws_df: pd.DataFrame, num_tickets: int):
+        numbers = list(range(1, 51))
+        stars = list(range(1, 13))
+
+        age_nums = {n: len(draws_df) for n in numbers}
+        age_stars = {s: len(draws_df) for s in stars}
+        seen_nums: set[int] = set()
+        seen_stars: set[int] = set()
+
+        for age, (_, row) in enumerate(draws_df.iloc[::-1].iterrows()):
+            for n in row["numbers"]:
+                n = int(n)
+                if n not in seen_nums:
+                    age_nums[n] = age
+                    seen_nums.add(n)
+            for s in row["stars"]:
+                s = int(s)
+                if s not in seen_stars:
+                    age_stars[s] = age
+                    seen_stars.add(s)
+            if len(seen_nums) == 50 and len(seen_stars) == 12:
+                break
+
+        num_weights = [(age_nums[n] + 1) ** exponent for n in numbers]
+        star_weights = [(age_stars[s] + 1) ** exponent for s in stars]
+
+        tickets = []
+        for _ in range(num_tickets):
+            picked_nums = set()
+            while len(picked_nums) < 5:
+                picked_nums.add(random.choices(numbers, weights=num_weights, k=1)[0])
+            picked_stars = set()
+            while len(picked_stars) < 2:
+                picked_stars.add(random.choices(stars, weights=star_weights, k=1)[0])
+            tickets.append((sorted(picked_nums), sorted(picked_stars)))
+        return tickets
+
+    generator.__name__ = f"age_weighted_exp{exponent}"
+    return generator
+
+
+def get_variants() -> list[callable]:
+    exps = [1.0, 2.0]
+    return [age_weighted_generator_factory(e) for e in exps]

--- a/src/euromillions/generators/strategies/decay_weighted.py
+++ b/src/euromillions/generators/strategies/decay_weighted.py
@@ -1,0 +1,44 @@
+import random
+import pandas as pd
+
+
+def decay_weighted_generator_factory(decay: float = 0.95, window: int | None = None):
+    """Exponential decay weighting of past draws."""
+
+    def generator(draws_df: pd.DataFrame, num_tickets: int):
+        df = draws_df if window is None else draws_df.tail(window)
+        numbers = list(range(1, 51))
+        stars = list(range(1, 13))
+
+        num_scores = {n: 0.0 for n in numbers}
+        star_scores = {s: 0.0 for s in stars}
+        for age, (_, row) in enumerate(df.iloc[::-1].iterrows()):
+            factor = decay ** age
+            for n in row["numbers"]:
+                num_scores[int(n)] += factor
+            for s in row["stars"]:
+                star_scores[int(s)] += factor
+
+        num_weights = [num_scores[n] + 1e-6 for n in numbers]
+        star_weights = [star_scores[s] + 1e-6 for s in stars]
+
+        tickets = []
+        for _ in range(num_tickets):
+            nums = set()
+            while len(nums) < 5:
+                nums.add(random.choices(numbers, weights=num_weights, k=1)[0])
+            stars_pick = set()
+            while len(stars_pick) < 2:
+                stars_pick.add(random.choices(stars, weights=star_weights, k=1)[0])
+            tickets.append((sorted(nums), sorted(stars_pick)))
+        return tickets
+
+    w_name = "all" if window is None else str(window)
+    generator.__name__ = f"decay{decay}_w{w_name}"
+    return generator
+
+
+def get_variants() -> list[callable]:
+    decays = [0.9, 0.95]
+    windows = [None, 20]
+    return [decay_weighted_generator_factory(d, w) for d in decays for w in windows]

--- a/src/euromillions/generators/strategies/pair_frequency.py
+++ b/src/euromillions/generators/strategies/pair_frequency.py
@@ -1,0 +1,54 @@
+import random
+from collections import Counter
+import pandas as pd
+
+
+def pair_frequency_generator_factory(window: int | None = None):
+    """Weight choices by historical pair frequencies."""
+
+    def generator(draws_df: pd.DataFrame, num_tickets: int):
+        df = draws_df if window is None else draws_df.tail(window)
+
+        pair_counts: Counter[frozenset[int]] = Counter()
+        base_counts: Counter[int] = Counter()
+
+        for _, row in df.iterrows():
+            nums = [int(n) for n in row["numbers"]]
+            base_counts.update(nums)
+            for i in range(len(nums)):
+                for j in range(i + 1, len(nums)):
+                    pair = frozenset({nums[i], nums[j]})
+                    pair_counts[pair] += 1
+
+        numbers = list(range(1, 51))
+
+        tickets = []
+        for _ in range(num_tickets):
+            picked = set()
+            weights = [base_counts[n] + 1 for n in numbers]
+            first = random.choices(numbers, weights=weights, k=1)[0]
+            picked.add(first)
+
+            while len(picked) < 5:
+                candidates = [n for n in numbers if n not in picked]
+                cand_w = []
+                for n in candidates:
+                    w = 1
+                    for p in picked:
+                        w += pair_counts[frozenset({n, p})]
+                    cand_w.append(w)
+                nxt = random.choices(candidates, weights=cand_w, k=1)[0]
+                picked.add(nxt)
+
+            stars = random.sample(range(1, 13), 2)
+            tickets.append((sorted(picked), sorted(stars)))
+        return tickets
+
+    w_name = "all" if window is None else str(window)
+    generator.__name__ = f"pair_freq_w{w_name}"
+    return generator
+
+
+def get_variants() -> list[callable]:
+    windows = [None, 30]
+    return [pair_frequency_generator_factory(w) for w in windows]

--- a/src/euromillions/generators/strategies/parity_balance.py
+++ b/src/euromillions/generators/strategies/parity_balance.py
@@ -1,0 +1,22 @@
+import random
+import pandas as pd
+
+
+def parity_balance_generator(draws_df: pd.DataFrame, num_tickets: int):
+    """Generate tickets matching the most common even/odd split."""
+    even_counts = draws_df["numbers"].apply(lambda ns: sum(1 for n in ns if int(n) % 2 == 0))
+    target_even = int(even_counts.mode()[0]) if not even_counts.empty else 2
+
+    evens = [n for n in range(1, 51) if n % 2 == 0]
+    odds = [n for n in range(1, 51) if n % 2 == 1]
+
+    tickets = []
+    for _ in range(num_tickets):
+        nums = random.sample(evens, target_even) + random.sample(odds, 5 - target_even)
+        stars = random.sample(range(1, 13), 2)
+        tickets.append((sorted(nums), sorted(stars)))
+    return tickets
+
+
+def get_variants() -> list[callable]:
+    return [parity_balance_generator]

--- a/src/euromillions/generators/strategies/sum_target.py
+++ b/src/euromillions/generators/strategies/sum_target.py
@@ -1,0 +1,32 @@
+import random
+import pandas as pd
+
+
+def sum_target_generator_factory(tolerance: float = 1.0):
+    """Bias selections toward sums near the historical average."""
+
+    def generator(draws_df: pd.DataFrame, num_tickets: int):
+        sums = draws_df["numbers"].apply(lambda ns: sum(int(n) for n in ns))
+        mean = sums.mean()
+        std = sums.std() if sums.std() > 0 else 1
+
+        numbers = list(range(1, 51))
+        tickets = []
+        for _ in range(num_tickets):
+            for _ in range(1000):
+                nums = sorted(random.sample(numbers, 5))
+                s = sum(nums)
+                if abs(s - mean) <= tolerance * std:
+                    stars = random.sample(range(1, 13), 2)
+                    tickets.append((nums, sorted(stars)))
+                    break
+            else:
+                tickets.append((sorted(random.sample(numbers, 5)), sorted(random.sample(range(1, 13), 2))))
+        return tickets
+
+    generator.__name__ = f"sum_target_{tolerance}".replace(".", "_")
+    return generator
+
+
+def get_variants() -> list[callable]:
+    return [sum_target_generator_factory(t) for t in [0.5, 1.0]]

--- a/src/euromillions/generators/strategy_registry.py
+++ b/src/euromillions/generators/strategy_registry.py
@@ -1,6 +1,11 @@
 from .strategies.frequency_weighted import get_variants as frequency_weighted_variants
 from .strategies.hot_cold import get_variants as hot_cold_variants
 from .strategies.markov_chain import get_variants as markov_chain_variants
+from .strategies.age_weighted import get_variants as age_weighted_variants
+from .strategies.decay_weighted import get_variants as decay_weighted_variants
+from .strategies.pair_frequency import get_variants as pair_frequency_variants
+from .strategies.parity_balance import get_variants as parity_balance_variants
+from .strategies.sum_target import get_variants as sum_target_variants
 from .ticket_generator import generate_tickets_from_variants
 
 __all__ = ["get_all_strategy_variants", "generate_tickets_from_variants"]
@@ -11,4 +16,9 @@ def get_all_strategy_variants() -> list:
     variants.extend(frequency_weighted_variants())
     variants.extend(hot_cold_variants())
     variants.extend(markov_chain_variants())
+    variants.extend(age_weighted_variants())
+    variants.extend(decay_weighted_variants())
+    variants.extend(pair_frequency_variants())
+    variants.extend(parity_balance_variants())
+    variants.extend(sum_target_variants())
     return variants


### PR DESCRIPTION
## Summary
- implement five new strategies for Euromillions ticket generation
  - `age_weighted`
  - `decay_weighted`
  - `pair_frequency`
  - `parity_balance`
  - `sum_target`
- include these in `strategy_registry`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6878f6c5ea848332803082057d5a6168