### PR TITLE
Add FFT-based ticket generation strategy

### DIFF
--- a/src/euromillions/generators/strategies/autocorrelation.py
+++ b/src/euromillions/generators/strategies/autocorrelation.py
@@ -1,0 +1,82 @@
+import random
+from typing import List, Tuple, Callable
+
+import numpy as np
+import pandas as pd
+
+Ticket = Tuple[List[int], List[int]]
+Generator = Callable[[pd.DataFrame, int], List[Ticket]]
+
+WINDOW_SIZES = [20, 50, 100]
+LAGS = [1, 2, 3, 4, 5]
+
+def _partial_autocorr(x: np.ndarray, lag: int) -> float:
+    """Compute a simple partial autocorrelation for given lag.
+
+    Uses Yule-Walker equations for AR(lag) model.
+    Returns 0.0 if computation fails.
+    """
+    n = len(x)
+    if lag >= n:
+        return 0.0
+    # autocorrelations for lags 0..lag
+    acf = [1.0]
+    for l in range(1, lag + 1):
+        if l >= n:
+            acf.append(0.0)
+        else:
+            val = pd.Series(x).autocorr(lag=l)
+            acf.append(0.0 if pd.isna(val) else val)
+    R = np.array([[acf[abs(i - j)] for j in range(lag)] for i in range(lag)])
+    r = np.array(acf[1:lag + 1])
+    try:
+        phi = np.linalg.solve(R, r)
+        val = float(phi[-1])
+        return 0.0 if np.isnan(val) else val
+    except np.linalg.LinAlgError:
+        return 0.0
+
+def _weights_for_balls(draw_series: pd.Series, balls: List[int], lag: int) -> List[float]:
+    arr = np.zeros((len(draw_series), len(balls)), dtype=int)
+    for idx, row in enumerate(draw_series):
+        for n in row:
+            arr[idx, int(n) - 1] = 1
+    weights: List[float] = []
+    for col in arr.T:
+        if lag < len(col):
+            ac_val = pd.Series(col).autocorr(lag=lag)
+            acf = 0.0 if pd.isna(ac_val) else ac_val
+            pacf = _partial_autocorr(col, lag)
+            pacf = 0.0 if pd.isna(pacf) else pacf
+            w = max(acf + pacf, 0.0) + 1.0
+        else:
+            w = 1.0
+        weights.append(w)
+    return weights
+
+def autocorr_generator_factory(window: int, lag: int) -> Generator:
+    def generator(draws_df: pd.DataFrame, max_tickets: int) -> List[Ticket]:
+        df = draws_df.tail(window) if window and len(draws_df) > window else draws_df
+        numbers = list(range(1, 51))
+        stars = list(range(1, 13))
+        num_weights = _weights_for_balls(df["numbers"], numbers, lag)
+        star_weights = _weights_for_balls(df["stars"], stars, lag)
+        tickets: List[Ticket] = []
+        for _ in range(max_tickets):
+            picked_nums = set()
+            while len(picked_nums) < 5:
+                picked_nums.add(random.choices(numbers, weights=num_weights, k=1)[0])
+            picked_stars = set()
+            while len(picked_stars) < 2:
+                picked_stars.add(random.choices(stars, weights=star_weights, k=1)[0])
+            tickets.append((sorted(picked_nums), sorted(picked_stars)))
+        return tickets
+    generator.__name__ = f"autocorr_w{window}_lag{lag}"
+    return generator
+
+def get_variants() -> List[Generator]:
+    variants: List[Generator] = []
+    for w in WINDOW_SIZES:
+        for l in LAGS:
+            variants.append(autocorr_generator_factory(w, l))
+    return variants

--- a/src/euromillions/generators/strategies/fft.py
+++ b/src/euromillions/generators/strategies/fft.py
@@ -1,0 +1,54 @@
+import random
+from typing import List, Tuple, Callable
+
+import numpy as np
+import pandas as pd
+
+Ticket = Tuple[List[int], List[int]]
+Generator = Callable[[pd.DataFrame, int], List[Ticket]]
+
+WINDOW_SIZES = [20, 50, 100]
+FREQ_INDICES = [1, 2, 3, 4, 5]
+
+def _fft_amplitudes(draw_series: pd.Series, balls: List[int], freq_idx: int) -> List[float]:
+    arr = np.zeros((len(draw_series), len(balls)))
+    for i, row in enumerate(draw_series):
+        for n in row:
+            arr[i, int(n) - 1] = 1.0
+    weights: List[float] = []
+    for col in arr.T:
+        fft_vals = np.fft.rfft(col)
+        if freq_idx < len(fft_vals):
+            amp = float(np.abs(fft_vals[freq_idx]))
+            w = amp + 1.0
+        else:
+            w = 1.0
+        weights.append(w)
+    return weights
+
+def fft_generator_factory(window: int, freq_idx: int) -> Generator:
+    def generator(draws_df: pd.DataFrame, max_tickets: int) -> List[Ticket]:
+        df = draws_df.tail(window) if window and len(draws_df) > window else draws_df
+        numbers = list(range(1, 51))
+        stars = list(range(1, 13))
+        num_weights = _fft_amplitudes(df["numbers"], numbers, freq_idx)
+        star_weights = _fft_amplitudes(df["stars"], stars, freq_idx)
+        tickets: List[Ticket] = []
+        for _ in range(max_tickets):
+            picked_nums = set()
+            while len(picked_nums) < 5:
+                picked_nums.add(random.choices(numbers, weights=num_weights, k=1)[0])
+            picked_stars = set()
+            while len(picked_stars) < 2:
+                picked_stars.add(random.choices(stars, weights=star_weights, k=1)[0])
+            tickets.append((sorted(picked_nums), sorted(picked_stars)))
+        return tickets
+    generator.__name__ = f"fft_w{window}_f{freq_idx}"
+    return generator
+
+def get_variants() -> List[Generator]:
+    variants: List[Generator] = []
+    for w in WINDOW_SIZES:
+        for f in FREQ_INDICES:
+            variants.append(fft_generator_factory(w, f))
+    return variants

--- a/src/euromillions/generators/strategy_registry.py
+++ b/src/euromillions/generators/strategy_registry.py
@@ -6,6 +6,8 @@ from .strategies.decay_weighted import get_variants as decay_weighted_variants
 from .strategies.pair_frequency import get_variants as pair_frequency_variants
 from .strategies.parity_balance import get_variants as parity_balance_variants
 from .strategies.sum_target import get_variants as sum_target_variants
+from .strategies.autocorrelation import get_variants as autocorrelation_variants
+from .strategies.fft import get_variants as fft_variants
 from .ticket_generator import generate_tickets_from_variants
 
 __all__ = ["get_all_strategy_variants", "generate_tickets_from_variants"]
@@ -21,4 +23,6 @@ def get_all_strategy_variants() -> list:
     variants.extend(pair_frequency_variants())
     variants.extend(parity_balance_variants())
     variants.extend(sum_target_variants())
+    variants.extend(autocorrelation_variants())
+    variants.extend(fft_variants())
     return variants


### PR DESCRIPTION
## Summary
- add FFT-based generator with configurable window sizes and frequency bins to weight numbers and stars
- register FFT strategy so it can be used alongside other ticket generators

## Testing
- `python -m euromillions fetch-draws` *(fails: ProxyError: HTTPSConnectionPool host 'euromillions.api.pedromealha.dev', 403 Forbidden)*
- `python -m euromillions stats` *(fails: FileNotFoundError: data/draws.parquet)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893356920a48332b33ae8e8d181c0a1